### PR TITLE
fix: Mayúsculas en siglas y corrección 'LYOSS' en biografía de Joaqui…

### DIFF
--- a/src/content/nosotros/miembros.json
+++ b/src/content/nosotros/miembros.json
@@ -111,7 +111,7 @@
     {
         "nombre": "Joaquin Velíz",
         "rol": "Coordinador",
-        "bio": "Vicepresidente del ceeinf y metido en las altas esferas de lyoos por azares del destino.",
+        "bio": "Vicepresidente del CEEINF y metido en las altas esferas de LYOSS por azares del destino.",
         "avatar": "https://avatars.githubusercontent.com/u/88526101?v=4",
         "githubUrl": "https://github.com/juaquo15",
         "linkedinUrl": "https://www.linkedin.com/in/joaquinveliz?utm_source=share&utm_campaign=share_via&utm_content=profile&utm_medium=android_app"


### PR DESCRIPTION
## Descripcion de los Cambios
- Fix typos biografía de Joaquín Veliz: "lyoos" -> "LYOSS", "ceeinf" -> "CEEINF"