### PR TITLE
refactor(hero): use local json for orbits data & remove github api

### DIFF
--- a/src/components/Landing/Hero.astro
+++ b/src/components/Landing/Hero.astro
@@ -8,7 +8,7 @@ if (!entry_content) {
 	throw new Error('No se encontró la entrada de contenido para contenidos/hero');
 }
 const { Content } = await entry_content.render();
-const orbits = await getOrbitsData();
+const orbits = getOrbitsData();
 ---
 
 <section id="hero" class="relative hero min-h-svh overflow-hidden pt-16">
@@ -29,7 +29,7 @@ const orbits = await getOrbitsData();
 									<div class={orbit.avatarClass}>
 										<Image
 											src={item.src}
-											alt="GitHub Member"
+											alt="Member"
 											width={32}
 											height={32}
 											format="webp"


### PR DESCRIPTION
## Issue Relacionada
Closes #34 

## Descripcion de los Cambios
Se elimino el uso de la API de GitHub apra traer los avatars de miembros de la organizacion que tuvieran publico su pertenencia  a Lyoss en la plataforma. hora los datos se consumen directamente desde src/content/nosotros/miembros.json, permitiendo mostrar a todos los coordinadores independientemente de la visibilidad de su perfil en la organización de GitHub.

## Estado de las Tareas

- [X] Modificar `src/utils/orbit.ts` para importar `miembros.json` en lugar de hacer `fetch` a GitHub.
- [X] Adaptar el mapeo de datos: Asignar la propiedad `avatar` del JSON a la propiedad `src` que espera el componente Hero.
- [X] Importante:Resolver la carga de imágenes locales en Astro. (ojo con esto)
- [X] Verificar que las imágenes remotas de github sigan cargando bien.

## Otros detalles
El orden de los miembros será aleatorio en cada deploy.